### PR TITLE
Add medication search API endpoint

### DIFF
--- a/Server/app.js
+++ b/Server/app.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const routes = require('./routes');
+
+const app = express();
+
+app.use(express.json());
+app.use('/api/v1', routes);
+
+module.exports = app;

--- a/Server/controllers/medicineController.js
+++ b/Server/controllers/medicineController.js
@@ -1,0 +1,16 @@
+const Medicine = require('../models/Medicine');
+
+// GET /api/v1/medications/search?q=paracetamol&limit=5
+exports.searchMedicines = async (req, res, next) => {
+  try {
+    const { q = '', limit = 10 } = req.query;
+    const query = q
+      ? { name: { $regex: q, $options: 'i' } }
+      : {};
+
+    const medicines = await Medicine.find(query).limit(Number(limit));
+    res.json(medicines);
+  } catch (err) {
+    next(err);
+  }
+};

--- a/Server/models/Medicine.js
+++ b/Server/models/Medicine.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const MedicineSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true
+  },
+  description: {
+    type: String,
+    default: ''
+  }
+});
+
+module.exports = mongoose.model('Medicine', MedicineSchema);

--- a/Server/routes/index.js
+++ b/Server/routes/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+
+const medicineRoutes = require('./medicineRoutes');
+
+router.use('/medications', medicineRoutes);
+
+module.exports = router;

--- a/Server/routes/medicineRoutes.js
+++ b/Server/routes/medicineRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { searchMedicines } = require('../controllers/medicineController');
+
+// GET /api/v1/medications/search
+router.get('/search', searchMedicines);
+
+module.exports = router;

--- a/Server/server.js
+++ b/Server/server.js
@@ -1,0 +1,6 @@
+const app = require('./app');
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement Mongoose Medicine model
- add controller and routes for GET `/api/v1/medications/search`
- wire router and app to expose the endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68955a890be883208cbaac0fdcf91392