### PR TITLE
Configure client API URL via environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/node_modules/
 **/.venv/
 **/.env
+!Client/.env

--- a/Client/.env
+++ b/Client/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/api/v1


### PR DESCRIPTION
## Summary
- add `.env` with `VITE_API_URL` for the client
- allow client `.env` to be tracked in git

## Testing
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68955a8ae1fc8320a53ccb87470c09dd