### PR TITLE
Use new prices API on compare page

### DIFF
--- a/Client/src/services/__tests__/api.test.js
+++ b/Client/src/services/__tests__/api.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import api, { pricesAPI } from '../api.js';
+
+describe('pricesAPI', () => {
+  it('URL-encodes medicine names with spaces and special characters', () => {
+    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({});
+
+    pricesAPI.get('Lipitor 10mg+50%');
+
+    expect(getSpy).toHaveBeenCalledWith('/prices/Lipitor%2010mg%2B50%25');
+
+    getSpy.mockRestore();
+  });
+});

--- a/Client/src/services/api.js
+++ b/Client/src/services/api.js
@@ -79,6 +79,11 @@ export const comparisonsAPI = {
   delete: (id) => api.delete(`/comparisons/${id}`),
 };
 
+// Prices API calls
+export const pricesAPI = {
+  get: (medicine) => api.get(`/prices/${encodeURIComponent(medicine)}`),
+};
+
 // Users API calls
 export const usersAPI = {
   getDashboard: () => api.get('/users/dashboard'),


### PR DESCRIPTION
## Summary
- add prices API helper for GET /prices/:medicine
- fetch price list on ComparePage using pricesAPI
- simplify comparison UI and render pharmacy, price and link table
- URL-encode medicine parameter when requesting prices to handle special characters
- add unit test verifying pricesAPI.get encodes medicine names

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68956c3bb9308320aa01d1326368ac9e